### PR TITLE
add jvm opt -Xms to reduce FGC

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
@@ -109,6 +109,7 @@ class SparkClassCommandBuilder extends AbstractCommandBuilder {
 
     String mem = firstNonEmpty(memKey != null ? System.getenv(memKey) : null, DEFAULT_MEM);
     cmd.add("-Xmx" + mem);
+    cmd.add("-Xms" + mem);
     cmd.add(className);
     cmd.addAll(classArgs);
     return cmd;


### PR DESCRIPTION
hi  
we found CoarseGrainedExecutorBackend process not used -Xms jvm opt, and this will lead to FGC frequently. 

we suggest to add jvm opt -Xms to reduce FGC .